### PR TITLE
docs: fix SSM info typo

### DIFF
--- a/docs/ssm_info.txt
+++ b/docs/ssm_info.txt
@@ -1,5 +1,5 @@
 The subaru select monitor protocol uses an ISO9141 interface and uses UART settings: 4800 bps n, 8, 1
-All data is sent and recieved using small packets that all share a common header.
+All data is sent and received using small packets that all share a common header.
 
 
 


### PR DESCRIPTION
## Summary
- fix "recieved" typo in SSM protocol documentation

## Testing
- `ant unittest` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a63b7125fc832496419984384e86ab