### PR TITLE
Handle variable-length OBD addresses

### DIFF
--- a/src/main/java/com/romraider/io/protocol/obd/iso15765/OBDLoggerProtocol.java
+++ b/src/main/java/com/romraider/io/protocol/obd/iso15765/OBDLoggerProtocol.java
@@ -166,19 +166,21 @@ public final class OBDLoggerProtocol implements LoggerProtocolOBD {
     }
 
     private byte[][] convertToByteAddresses(Collection<EcuQuery> queries) {
-        int byteCount = 0;
+        int addrCount = 0;
         for (EcuQuery query : queries) {
-            byteCount += query.getAddresses().length;
+            addrCount += query.getAddresses().length;
         }
-        final int ADDRESS_SIZE = 1;
-        // TODO how do we handle variable address lengths ?
-        final byte[][] addresses = new byte[byteCount][ADDRESS_SIZE];
+
+        final byte[][] addresses = new byte[addrCount][];
         int i = 0;
         for (EcuQuery query : queries) {
-            final int addrLength = query.getBytes().length;
             final byte[] bytes = query.getBytes();
-            for (int j = 0; j < bytes.length / addrLength; j++) {
-                arraycopy(bytes, j * addrLength, addresses[i++], 0, addrLength);
+            final int count = query.getAddresses().length;
+            final int addrLength = bytes.length / count;
+            for (int j = 0; j < count; j++) {
+                addresses[i] = new byte[addrLength];
+                arraycopy(bytes, j * addrLength, addresses[i], 0, addrLength);
+                i++;
             }
         }
         return addresses;

--- a/src/test/java/com/romraider/io/protocol/obd/iso15765/OBDLoggerProtocolTest.java
+++ b/src/test/java/com/romraider/io/protocol/obd/iso15765/OBDLoggerProtocolTest.java
@@ -1,0 +1,87 @@
+package com.romraider.io.protocol.obd.iso15765;
+
+import static com.romraider.util.HexUtil.asBytes;
+import static com.romraider.util.HexUtil.asHex;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+
+import com.romraider.logger.ecu.comms.query.EcuQuery;
+import com.romraider.logger.ecu.definition.LoggerData;
+
+public class OBDLoggerProtocolTest {
+
+    private static class DummyQuery implements EcuQuery {
+        private final String[] addresses;
+        private final byte[] bytes;
+        private final String hex;
+
+        DummyQuery(String... addresses) {
+            this.addresses = addresses;
+            int len = 0;
+            for (String addr : addresses) {
+                len += asBytes(addr).length;
+            }
+            byte[] tmp = new byte[len];
+            int pos = 0;
+            for (String addr : addresses) {
+                byte[] b = asBytes(addr);
+                System.arraycopy(b, 0, tmp, pos, b.length);
+                pos += b.length;
+            }
+            this.bytes = tmp;
+            this.hex = asHex(tmp);
+        }
+
+        @Override
+        public String[] getAddresses() {
+            return addresses;
+        }
+
+        @Override
+        public byte[] getBytes() {
+            return bytes;
+        }
+
+        @Override
+        public String getHex() {
+            return hex;
+        }
+
+        @Override
+        public void setResponse(byte[] bytes) {
+        }
+
+        @Override
+        public LoggerData getLoggerData() {
+            return null;
+        }
+
+        @Override
+        public double getResponse() {
+            return 0;
+        }
+    }
+
+    @Test
+    public void convertsMultiByteAddresses() throws Exception {
+        OBDLoggerProtocol protocol = new OBDLoggerProtocol();
+        DummyQuery q1 = new DummyQuery("0x1234", "0x5678");
+        DummyQuery q2 = new DummyQuery("0x9A");
+
+        Collection<EcuQuery> queries = Arrays.asList(q1, q2);
+        Method m = OBDLoggerProtocol.class.getDeclaredMethod("convertToByteAddresses", Collection.class);
+        m.setAccessible(true);
+        byte[][] result = (byte[][]) m.invoke(protocol, queries);
+
+        assertEquals(3, result.length);
+        assertArrayEquals(new byte[]{0x12, 0x34}, result[0]);
+        assertArrayEquals(new byte[]{0x56, 0x78}, result[1]);
+        assertArrayEquals(new byte[]{(byte) 0x9A}, result[2]);
+    }
+}


### PR DESCRIPTION
## Summary
- Support queries with varying address lengths in OBDLoggerProtocol.
- Add unit test to ensure multi-byte addresses are processed correctly.

## Testing
- `ant unittest` *(failed: command not found)*
- `apt-get update` *(failed: repository not signed)*
- `javac -d /tmp/test-classes -cp "$(echo lib/common/*.jar lib/linux/*.jar lib/testing/junit.jar lib/testing/hamcrest.jar | tr ' ' ':')" @/tmp/sources.txt` *(failed: missing Version class and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a73d1fd5e08324b8d9b5d60c61d855