### PR TITLE
Add configurable file debug logging

### DIFF
--- a/i18n/com/romraider/logger/ecu/ui/swing/menubar/EcuLoggerMenuBar.properties
+++ b/i18n/com/romraider/logger/ecu/ui/swing/menubar/EcuLoggerMenuBar.properties
@@ -48,4 +48,6 @@ INFO = INFO - normal
 DEBUG = DEBUG - detailed
 TRACE = TRACE - verbose
 DEBUGLOC = Open Debug Log Location ...
+DEBUGTOFILE = Enable Debug Log File
+DEBUGTOFILETT = Toggle detailed logger output to file
 ABOUT = About {0}

--- a/src/main/java/com/romraider/Settings.java
+++ b/src/main/java/com/romraider/Settings.java
@@ -236,6 +236,7 @@ public class Settings implements Serializable {
     private boolean fastPoll = true;
     private double loggerDividerLocation = 400;
     private String loggerDebuggingLevel = "info";
+    private boolean debugToFile;
     private static String j2534Device = "";
     private static String transportProtocol = ISO9141;
 
@@ -760,6 +761,14 @@ public class Settings implements Serializable {
 
     public String getLoggerDebuggingLevel() {
         return loggerDebuggingLevel;
+    }
+
+    public boolean isDebugToFile() {
+        return debugToFile;
+    }
+
+    public void setDebugToFile(boolean debugToFile) {
+        this.debugToFile = debugToFile;
     }
 
     public void setJ2534Device(String j2534Device) {

--- a/src/main/java/com/romraider/logger/ecu/EcuLogger.java
+++ b/src/main/java/com/romraider/logger/ecu/EcuLogger.java
@@ -112,6 +112,9 @@ import javax.swing.table.TableColumn;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
+import org.apache.log4j.Appender;
+import org.apache.log4j.PatternLayout;
+import org.apache.log4j.RollingFileAppender;
 
 import com.romraider.Settings;
 import com.romraider.Version;
@@ -221,6 +224,7 @@ public final class EcuLogger extends AbstractFrame implements MessageListener {
     private static final String ECU_LOGGER_TITLE = PRODUCT_NAME + " v" + VERSION + " | " + rb.getString("TITLE");
     private static final String LOGGER_FULLSCREEN_ARG = "-logger.fullscreen";
     private static final String LOGGER_TOUCH_ARG = "-logger.touch";
+    private static final String LOGGER_DEBUG_FILE_ARG = "-logger.debugfile";
     private static final URL ICON_PATH =  Settings.class.getResource("/graphics/romraider-ico.gif");
     private static final String HEADING_PARAMETERS = "Parameters";
     private static final String HEADING_SWITCHES = "Switches";
@@ -306,6 +310,7 @@ public final class EcuLogger extends AbstractFrame implements MessageListener {
     private Map<String, Object> componentList = new HashMap<String, Object>();
     private static boolean touchEnabled = false;
     private final JPanel moduleSelectPanel = new JPanel(new FlowLayout());
+    private Appender debugFileAppender;
 
     private static EcuLogger instance;
 
@@ -342,10 +347,18 @@ public final class EcuLogger extends AbstractFrame implements MessageListener {
     }
 
     private void construct() {
-        /**
-         * Bitness of supporting libraries must match the bitness of RomRaider
-         * and the running JRE.  Notify and exit if mixed bitness is detected.
-         */
+        checkArchitecture();
+        initLogging();
+        if (ecuEditor == null) {
+            startStandalone();
+        }
+        else {
+            startEmbedded();
+        }
+        this.toFront();
+    }
+
+    private void checkArchitecture() {
         if (!System.getProperty("sun.arch.data.model").equals(Version.BUILD_ARCH)) {
             showMessageDialog(null,
                     MessageFormat.format(
@@ -353,56 +366,84 @@ public final class EcuLogger extends AbstractFrame implements MessageListener {
                             PRODUCT_NAME, Version.BUILD_ARCH),
                 rb.getString("INCOMPJREERR"),
                 ERROR_MESSAGE);
-            // this will generate a NullPointerException because we never got
-            // things started
             WindowEvent e = new WindowEvent(this, WindowEvent.WINDOW_CLOSED);
             windowClosing(e);
         }
+    }
+
+    private void initLogging() {
         checkNotNull(getSettings());
         Logger.getRootLogger().setLevel(Level.toLevel(getSettings().getLoggerDebuggingLevel()));
+        enableDebugToFile(getSettings().isDebugToFile());
         LOGGER.info("Logger locale: " + System.getProperty("user.language") +
                 "_" + System.getProperty("user.country"));
+    }
 
-        if (ecuEditor == null) {
-            JProgressBar progressBar = startbar();
-            bootstrap();
-            progressBar.setValue(20);
-            startText.setText(rb.getString("LOADINGDEFS"));
-            loadEcuDefs();
-            progressBar.setValue(40);
-            startText.setText(rb.getString("LOADINGPLUG"));
-            progressBar.setIndeterminate(true);
-            loadLoggerPlugins();
-            progressBar.setIndeterminate(false);
-            progressBar.setValue(60);
-            startText.setText(rb.getString("LOADINGPARAMS"));
-            loadLoggerParams();
-            progressBar.setValue(80);
-            startText.setText(rb.getString("STARTINGLOGGER"));
-            initControllerListeners();
-            initUserInterface();
-            progressBar.setValue(100);
-            initDataUpdateHandlers();
-            startPortRefresherThread();
-            startStatus.dispose();
+    private void startStandalone() {
+        JProgressBar progressBar = startbar();
+        bootstrap();
+        progressBar.setValue(20);
+        startText.setText(rb.getString("LOADINGDEFS"));
+        loadEcuDefs();
+        progressBar.setValue(40);
+        startText.setText(rb.getString("LOADINGPLUG"));
+        progressBar.setIndeterminate(true);
+        loadLoggerPlugins();
+        progressBar.setIndeterminate(false);
+        progressBar.setValue(60);
+        startText.setText(rb.getString("LOADINGPARAMS"));
+        loadLoggerParams();
+        progressBar.setValue(80);
+        startText.setText(rb.getString("STARTINGLOGGER"));
+        initControllerListeners();
+        initUserInterface();
+        progressBar.setValue(100);
+        initDataUpdateHandlers();
+        startPortRefresherThread();
+        startStatus.dispose();
+    }
+
+    private void startEmbedded() {
+        bootstrap();
+        ecuEditor.getStatusPanel().update(rb.getString("LOADINGDEFS"), 20);
+        loadEcuDefs();
+        ecuEditor.getStatusPanel().update(rb.getString("LOADINGPLUG"), 40);
+        loadLoggerPlugins();
+        ecuEditor.getStatusPanel().update(rb.getString("LOADINGPARAMS"), 60);
+        loadLoggerParams();
+        ecuEditor.getStatusPanel().update(rb.getString("STARTINGLOGGER"), 80);
+        initControllerListeners();
+        initUserInterface();
+        ecuEditor.getStatusPanel().update(rb.getString("COMPLETE"), 100);
+        initDataUpdateHandlers();
+        startPortRefresherThread();
+        ecuEditor.getStatusPanel().update(rb.getString("READY"),0);
+    }
+
+    public void enableDebugToFile(boolean enable) {
+        Logger root = Logger.getRootLogger();
+        if (enable) {
+            if (debugFileAppender == null) {
+                try {
+                    File logDir = new File(System.getProperty("user.home"), ".RomRaider");
+                    logDir.mkdirs();
+                    String path = logDir.getAbsolutePath() + "/rr_logger_debug.log";
+                    debugFileAppender = new RollingFileAppender(new PatternLayout("%d{ABSOLUTE} %-5p [%t] - %m%n"), path, true);
+                    debugFileAppender.setName("debugFile");
+                } catch (Exception e) {
+                    LOGGER.error("Unable to create debug log file", e);
+                }
+            }
+            if (debugFileAppender != null && root.getAppender("debugFile") == null) {
+                root.addAppender(debugFileAppender);
+            }
+        } else {
+            Appender app = root.getAppender("debugFile");
+            if (app != null) {
+                root.removeAppender(app);
+            }
         }
-        else {
-            bootstrap();
-            ecuEditor.getStatusPanel().update(rb.getString("LOADINGDEFS"), 20);
-            loadEcuDefs();
-            ecuEditor.getStatusPanel().update(rb.getString("LOADINGPLUG"), 40);
-            loadLoggerPlugins();
-            ecuEditor.getStatusPanel().update(rb.getString("LOADINGPARAMS"), 60);
-            loadLoggerParams();
-            ecuEditor.getStatusPanel().update(rb.getString("STARTINGLOGGER"), 80);
-            initControllerListeners();
-            initUserInterface();
-            ecuEditor.getStatusPanel().update(rb.getString("COMPLETE"), 100);
-            initDataUpdateHandlers();
-            startPortRefresherThread();
-            ecuEditor.getStatusPanel().update(rb.getString("READY"),0);
-        }
-        this.toFront();
+        getSettings().setDebugToFile(enable);
     }
 
     private void bootstrap() {
@@ -2132,7 +2173,11 @@ public final class EcuLogger extends AbstractFrame implements MessageListener {
     public static void startLogger(int defaultCloseOperation, ECUEditor ecuEditor, String[] args) {
         touchEnabled = setTouchEnabled(args);
         boolean fullscreen = containsFullScreenArg(args);
+        boolean debugToFile = containsDebugFileArg(args);
         EcuLogger ecuLogger = getEcuLogger(ecuEditor);
+        if (debugToFile) {
+            ecuLogger.enableDebugToFile(true);
+        }
         createAndShowGui(defaultCloseOperation, ecuLogger, fullscreen);
         if (ecuLogger.getSettings().getAutoConnectOnStartup() && !ecuLogger.isLogging()) ecuLogger.startLogging();
     }
@@ -2147,10 +2192,18 @@ public final class EcuLogger extends AbstractFrame implements MessageListener {
     }
 
     private static boolean setTouchEnabled(String... args) {
-    	if(args == null) return false;
+        if(args == null) return false;
 
         for (String arg : args) {
             if (LOGGER_TOUCH_ARG.equalsIgnoreCase(arg)) return true;
+        }
+        return false;
+    }
+
+    private static boolean containsDebugFileArg(String... args) {
+        if (args == null) return false;
+        for (String arg : args) {
+            if (LOGGER_DEBUG_FILE_ARG.equalsIgnoreCase(arg)) return true;
         }
         return false;
     }

--- a/src/main/java/com/romraider/logger/ecu/ui/swing/menubar/EcuLoggerMenuBar.java
+++ b/src/main/java/com/romraider/logger/ecu/ui/swing/menubar/EcuLoggerMenuBar.java
@@ -73,6 +73,7 @@ import com.romraider.logger.ecu.ui.swing.menubar.action.LogFileControllerSwitchA
 import com.romraider.logger.ecu.ui.swing.menubar.action.LogFileLocationAction;
 import com.romraider.logger.ecu.ui.swing.menubar.action.LogFileNumberFormatAction;
 import com.romraider.logger.ecu.ui.swing.menubar.action.LoggerDebugLocationAction;
+import com.romraider.logger.ecu.ui.swing.menubar.action.LoggerDebugFileAction;
 import com.romraider.logger.ecu.ui.swing.menubar.action.LoggerDebuggingLevelAction;
 import com.romraider.logger.ecu.ui.swing.menubar.action.LoggerDefinitionLocationAction;
 import com.romraider.logger.ecu.ui.swing.menubar.action.ReadEcuCodesAction;
@@ -196,6 +197,9 @@ public class EcuLoggerMenuBar extends JMenuBar {
         debug.add(info);
         debug.add(db);
         debug.add(trace);
+        RadioButtonMenuItem debugFile = new RadioButtonMenuItem(rb.getString("DEBUGTOFILE"), VK_F, null, new LoggerDebugFileAction(logger), logger.getSettings().isDebugToFile());
+        debugFile.setToolTipText(rb.getString("DEBUGTOFILETT"));
+        debug.add(debugFile);
         debug.add(new JSeparator());
         debug.add(new MenuItem(rb.getString("DEBUGLOC"), new LoggerDebugLocationAction(logger), VK_O, getKeyStroke(VK_O, ALT_MASK)));
         helpMenu.add(debug);

--- a/src/main/java/com/romraider/logger/ecu/ui/swing/menubar/action/LoggerDebugFileAction.java
+++ b/src/main/java/com/romraider/logger/ecu/ui/swing/menubar/action/LoggerDebugFileAction.java
@@ -1,0 +1,42 @@
+/*
+ * RomRaider Open-Source Tuning, Logging and Reflashing
+ * Copyright (C) 2006-2022 RomRaider.com
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.romraider.logger.ecu.ui.swing.menubar.action;
+
+import java.awt.event.ActionEvent;
+
+import com.romraider.logger.ecu.EcuLogger;
+import com.romraider.swing.menubar.action.AbstractAction;
+
+public final class LoggerDebugFileAction extends AbstractAction {
+
+    public LoggerDebugFileAction(EcuLogger logger) {
+        super(logger);
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent actionEvent) {
+        try {
+            logger.enableDebugToFile((Boolean) getValue(SELECTED_KEY));
+        } catch (Exception e) {
+            logger.reportError(e);
+        }
+    }
+}
+

--- a/src/main/java/com/romraider/swing/SettingsForm.java
+++ b/src/main/java/com/romraider/swing/SettingsForm.java
@@ -923,6 +923,7 @@ public class SettingsForm extends JFrame implements MouseListener {
             newSettings.setUserLevel(curSettings.getUserLevel());
             newSettings.setLoggerDefinitionFilePath(curSettings.getLoggerDefinitionFilePath());
             newSettings.setLoggerDebuggingLevel(curSettings.getLoggerDebuggingLevel());
+            newSettings.setDebugToFile(curSettings.isDebugToFile());
             newSettings.setLoggerProfileFilePath(curSettings.getLoggerProfileFilePath());
             newSettings.setLoggerOutputDirPath(curSettings.getLoggerOutputDirPath());
 

--- a/src/main/java/com/romraider/xml/DOMSettingsBuilder.java
+++ b/src/main/java/com/romraider/xml/DOMSettingsBuilder.java
@@ -392,6 +392,7 @@ public final class DOMSettingsBuilder {
         // debug level
         IIOMetadataNode debug = new IIOMetadataNode("debug");
         debug.setAttribute("level", settings.getLoggerDebuggingLevel());
+        debug.setAttribute("tofile", String.valueOf(settings.isDebugToFile()));
         loggerSettings.appendChild(debug);
 
         // plugin ports

--- a/src/main/java/com/romraider/xml/DOMSettingsUnmarshaller.java
+++ b/src/main/java/com/romraider/xml/DOMSettingsUnmarshaller.java
@@ -302,6 +302,7 @@ public final class DOMSettingsUnmarshaller {
 
             } else if (n.getNodeType() == ELEMENT_NODE && n.getNodeName().equalsIgnoreCase("debug")) {
                 settings.setLoggerDebuggingLevel(unmarshallAttribute(n, "level", "info"));
+                settings.setDebugToFile(unmarshallAttribute(n, "tofile", false));
 
             } else if (n.getNodeType() == ELEMENT_NODE && n.getNodeName().equalsIgnoreCase("gauge")) {
                 settings.setLoggerSelectedGaugeIndex(unmarshallAttribute(n, "index", 0));


### PR DESCRIPTION
## Summary
- Allow enabling detailed logger output to a file via settings, UI toggle or `-logger.debugfile` flag
- Persist debug-file preference in settings XML
- Refactor EcuLogger startup logic into smaller methods for clarity

## Testing
- `ant -noinput build` *(fails: Unable to create javax script engine for javascript)*

------
https://chatgpt.com/codex/tasks/task_e_68a73f1064d4832484e1270c8410253e