### PR TITLE
Implement ECU reset request/response handling for NCS ISO15765

### DIFF
--- a/src/test/java/com/romraider/io/protocol/ncs/iso15765/NCSProtocolTest.java
+++ b/src/test/java/com/romraider/io/protocol/ncs/iso15765/NCSProtocolTest.java
@@ -1,0 +1,46 @@
+package com.romraider.io.protocol.ncs.iso15765;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import org.junit.Test;
+
+import com.romraider.logger.ecu.definition.Module;
+import com.romraider.logger.ecu.exception.InvalidResponseException;
+
+public class NCSProtocolTest {
+
+    private Module createModule() {
+        return new Module(
+                "ECU",
+                new byte[] {0x00, 0x00, 0x07, (byte) 0xE8},
+                "dummy",
+                new byte[] {0x00, 0x00, 0x07, (byte) 0xE0},
+                false);
+    }
+
+    @Test
+    public void constructsResetRequest() {
+        NCSProtocol protocol = new NCSProtocol();
+        Module module = createModule();
+        byte[] request = protocol.constructEcuResetRequest(module, 0x01);
+        assertArrayEquals(new byte[] {0x00, 0x00, 0x07, (byte) 0xE0, 0x11, 0x01}, request);
+    }
+
+    @Test
+    public void acceptsValidResetResponse() {
+        NCSProtocol protocol = new NCSProtocol();
+        Module module = createModule();
+        protocol.constructEcuResetRequest(module, 0x01);
+        byte[] response = new byte[] {0x00, 0x00, 0x07, (byte) 0xE8, 0x51, 0x01};
+        protocol.checkValidEcuResetResponse(response);
+    }
+
+    @Test(expected = InvalidResponseException.class)
+    public void rejectsInvalidResetResponse() {
+        NCSProtocol protocol = new NCSProtocol();
+        Module module = createModule();
+        protocol.constructEcuResetRequest(module, 0x01);
+        byte[] response = new byte[] {0x00, 0x00, 0x07, (byte) 0xE8, 0x51, 0x02};
+        protocol.checkValidEcuResetResponse(response);
+    }
+}


### PR DESCRIPTION
## Summary
- Support configurable Service $11 ECU reset request in NCS ISO15765 protocol
- Validate ECU reset responses against expected address and reset code
- Add unit tests for reset request construction and response validation

## Testing
- ⚠️ `ant -q unittest` *(failed: Unable to create javax script engine for javascript)*

------
https://chatgpt.com/codex/tasks/task_e_68a73f0cbde8832485512653489a8a56