### PR TITLE
Add tab shortcuts and persist tab warning thresholds

### DIFF
--- a/src/main/java/com/romraider/Settings.java
+++ b/src/main/java/com/romraider/Settings.java
@@ -33,6 +33,7 @@ import java.io.Serializable;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Vector;
+import java.util.HashMap;
 
 import com.romraider.io.connection.ConnectionProperties;
 import com.romraider.logger.ecu.definition.EcuDefinition;
@@ -227,6 +228,7 @@ public class Settings implements Serializable {
     private int loggerSelectedTabIndex;
     private int loggerSelectedGaugeIndex = 0;
     private boolean loggerParameterListState = true;
+    private Map<String, Integer> tabWarningThresholds = new HashMap<String, Integer>();
     private ConnectionProperties loggerConnectionProperties;
     private Map<String, EcuDefinition> loggerEcuDefinitionMap;
     private Map<String, String> loggerPluginPorts;
@@ -712,6 +714,22 @@ public class Settings implements Serializable {
 
     public boolean getLoggerParameterListState() {
         return loggerParameterListState;
+    }
+
+    public Map<String, Integer> getTabWarningThresholds() {
+        return tabWarningThresholds;
+    }
+
+    public void setTabWarningThresholds(Map<String, Integer> thresholds) {
+        this.tabWarningThresholds = thresholds;
+    }
+
+    public int getTabWarningThreshold(String tab) {
+        return tabWarningThresholds.containsKey(tab) ? tabWarningThresholds.get(tab) : 0;
+    }
+
+    public void setTabWarningThreshold(String tab, int threshold) {
+        tabWarningThresholds.put(tab, threshold);
     }
 
     public void setRefreshMode(boolean selected) {

--- a/src/main/java/com/romraider/logger/ecu/EcuLogger.java
+++ b/src/main/java/com/romraider/logger/ecu/EcuLogger.java
@@ -43,6 +43,7 @@ import static java.lang.System.currentTimeMillis;
 import static java.util.Collections.sort;
 import static javax.swing.BorderFactory.createLoweredBevelBorder;
 import static javax.swing.JComponent.WHEN_IN_FOCUSED_WINDOW;
+import static javax.swing.JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT;
 import static javax.swing.JOptionPane.DEFAULT_OPTION;
 import static javax.swing.JOptionPane.ERROR_MESSAGE;
 import static javax.swing.JOptionPane.INFORMATION_MESSAGE;
@@ -106,6 +107,8 @@ import javax.swing.JTable;
 import javax.swing.JTextField;
 import javax.swing.JToggleButton;
 import javax.swing.JWindow;
+import javax.swing.InputMap;
+import javax.swing.ActionMap;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.table.TableColumn;
@@ -1066,10 +1069,26 @@ public final class EcuLogger extends AbstractFrame implements MessageListener {
             public void stateChanged(ChangeEvent e) {
                 if(tabbedPane.getSelectedComponent() == dynoTab.getPanel())
                 {
-                	((DynoTabImpl)dynoTab).getDynoControlPanel().checkDynoDefs();
+                        ((DynoTabImpl)dynoTab).getDynoControlPanel().checkDynoDefs();
                 }
             }
         });
+
+        InputMap im = tabbedPane.getInputMap(WHEN_IN_FOCUSED_WINDOW);
+        ActionMap am = tabbedPane.getActionMap();
+        for (int i = 0; i < tabbedPane.getTabCount(); i++) {
+            final int index = i;
+            String actionKey = "selectTab" + i;
+            im.put(getKeyStroke("ctrl " + (i + 1)), actionKey);
+            am.put(actionKey, new AbstractAction() {
+                private static final long serialVersionUID = 1L;
+
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    tabbedPane.setSelectedIndex(index);
+                }
+            });
+        }
 
         return tabbedPane;
     }
@@ -1301,6 +1320,25 @@ public final class EcuLogger extends AbstractFrame implements MessageListener {
             changeColumnWidth(paramListTable, 0, 20, 75, 75);
             changeColumnWidth(paramListTable, 2, 50, 75, 75);
         }
+
+        paramListTable.getInputMap(WHEN_ANCESTOR_OF_FOCUSED_COMPONENT).put(getKeyStroke("SPACE"), "toggleParam");
+        paramListTable.getActionMap().put("toggleParam", new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                int row = paramListTable.getSelectedRow();
+                if (row >= 0) {
+                    int modelRow = paramListTable.convertRowIndexToModel(row);
+                    ParameterRow pr = tableModel.getParameterRows().get(modelRow);
+                    boolean selected = !pr.isSelected();
+                    tableModel.selectParam(pr.getLoggerData(), selected);
+                    pr.setSelected(selected);
+                    tableModel.fireTableRowsUpdated(modelRow, modelRow);
+                }
+            }
+        });
+
         return paramListTable;
     }
 

--- a/src/main/java/com/romraider/xml/DOMSettingsBuilder.java
+++ b/src/main/java/com/romraider/xml/DOMSettingsBuilder.java
@@ -371,6 +371,18 @@ public final class DOMSettingsBuilder {
         tabs.setAttribute("showlist", String.valueOf(settings.getLoggerParameterListState()));
         loggerSettings.appendChild(tabs);
 
+        Map<String, Integer> tabPrefs = settings.getTabWarningThresholds();
+        if (tabPrefs != null && !tabPrefs.isEmpty()) {
+            IIOMetadataNode prefs = new IIOMetadataNode("tabprefs");
+            for (Map.Entry<String, Integer> entry : tabPrefs.entrySet()) {
+                IIOMetadataNode tab = new IIOMetadataNode("tab");
+                tab.setAttribute("name", entry.getKey());
+                tab.setAttribute("warning", String.valueOf(entry.getValue()));
+                prefs.appendChild(tab);
+            }
+            loggerSettings.appendChild(prefs);
+        }
+
         // definition path
         IIOMetadataNode definition = new IIOMetadataNode("definition");
         definition.setAttribute("path", settings.getLoggerDefinitionFilePath());

--- a/src/main/java/com/romraider/xml/DOMSettingsUnmarshaller.java
+++ b/src/main/java/com/romraider/xml/DOMSettingsUnmarshaller.java
@@ -288,6 +288,21 @@ public final class DOMSettingsUnmarshaller {
                 settings.setLoggerSelectedTabIndex(unmarshallAttribute(n, "selected", 0));
                 settings.setLoggerParameterListState(unmarshallAttribute(n, "showlist", true));
 
+            } else if (n.getNodeType() == ELEMENT_NODE && n.getNodeName().equalsIgnoreCase("tabprefs")) {
+                Map<String, Integer> prefs = new HashMap<String, Integer>();
+                NodeList prefNodes = n.getChildNodes();
+                for (int j = 0; j < prefNodes.getLength(); j++) {
+                    Node tab = prefNodes.item(j);
+                    if (tab.getNodeType() == ELEMENT_NODE && tab.getNodeName().equalsIgnoreCase("tab")) {
+                        String name = unmarshallAttribute(tab, "name", null);
+                        int warn = unmarshallAttribute(tab, "warning", 0);
+                        if (name != null) {
+                            prefs.put(name, warn);
+                        }
+                    }
+                }
+                settings.setTabWarningThresholds(prefs);
+
             } else if (n.getNodeType() == ELEMENT_NODE && n.getNodeName().equalsIgnoreCase("definition")) {
                 settings.setLoggerDefinitionFilePath(unmarshallAttribute(n, "path", settings.getLoggerDefinitionFilePath()));
 

--- a/src/test/java/com/romraider/util/SettingsPersistenceTest.java
+++ b/src/test/java/com/romraider/util/SettingsPersistenceTest.java
@@ -1,0 +1,63 @@
+/*
+ * RomRaider Open-Source Tuning, Logging and Reflashing
+ * Copyright (C) 2006-2024 RomRaider.com
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.romraider.util;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+
+import com.romraider.Settings;
+import com.romraider.swing.JProgressPane;
+import com.romraider.xml.DOMSettingsBuilder;
+import com.romraider.xml.DOMSettingsUnmarshaller;
+
+public class SettingsPersistenceTest {
+
+    @Test
+    public void tabWarningThresholdsPersist() throws Exception {
+        Settings settings = new Settings();
+        Map<String, Integer> thresholds = new HashMap<String, Integer>();
+        thresholds.put("Data", 90);
+        thresholds.put("Graph", 80);
+        settings.setTabWarningThresholds(thresholds);
+
+        File file = File.createTempFile("settings", ".xml");
+        new DOMSettingsBuilder().buildSettings(settings, file, new JProgressPane(), "test");
+
+        InputSource src = new InputSource(new FileInputStream(file));
+        DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        Document doc = builder.parse(src);
+        Settings loaded = new DOMSettingsUnmarshaller().unmarshallSettings(doc.getDocumentElement());
+
+        assertEquals(thresholds, loaded.getTabWarningThresholds());
+        file.delete();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Ctrl+number shortcuts for logger tabs and space toggling for parameters
- store tab-specific warning thresholds in settings
- test tab warning threshold persistence

## Testing
- `ant unittest` *(fails: Unable to create javax script engine for javascript)*

------
https://chatgpt.com/codex/tasks/task_e_68a73f11cff48324a33af0a2a8cc3d6a