### PR TITLE
Use boolean accessor for ELM327 setting

### DIFF
--- a/src/main/java/com/romraider/Settings.java
+++ b/src/main/java/com/romraider/Settings.java
@@ -283,7 +283,7 @@ public class Settings implements Serializable {
     /**
      * Sets if we search for the ELM327 on startup (small delay)
      */
-	private Boolean searchElm327 = false;
+    private boolean searchElm327 = false;
 
     public Settings() {
         //center window by default
@@ -995,9 +995,9 @@ public class Settings implements Serializable {
         return this.tpsThreshold;
     }
 
-	public boolean getElm327Enabled() {
-		return this.searchElm327;
-	}
+    public boolean isElm327Enabled() {
+        return this.searchElm327;
+    }
 
     public void setSelectedCar(final String value) {
         this.selectedCar = value;
@@ -1015,9 +1015,9 @@ public class Settings implements Serializable {
         this.tpsThreshold = value;
     }
 
-	public void setElm327Enabled(Boolean value) {
-		this.searchElm327 = value;
-	}
+    public void setElm327Enabled(boolean value) {
+        this.searchElm327 = value;
+    }
 
     public void setTableTreeSorted(Boolean value) {
         this.sortTableTree = value;

--- a/src/main/java/com/romraider/io/connection/ConnectionManagerFactory.java
+++ b/src/main/java/com/romraider/io/connection/ConnectionManagerFactory.java
@@ -49,7 +49,7 @@ public final class ConnectionManagerFactory {
         // Try a serial connection
         if (isNullOrEmpty(settings.getJ2534Device())) {
 
-            if(SettingsManager.getSettings().getElm327Enabled()) {
+            if(SettingsManager.getSettings().isElm327Enabled()) {
                 LOGGER.info("Trying to connect to ELM327...");
                 manager = new ElmConnectionManager(portName, connectionProperties);
             }

--- a/src/main/java/com/romraider/logger/ecu/EcuLogger.java
+++ b/src/main/java/com/romraider/logger/ecu/EcuLogger.java
@@ -2260,9 +2260,9 @@ public final class EcuLogger extends AbstractFrame implements MessageListener {
         getSettings().setAutoConnectOnStartup(connect);
     }
 
-	public void setElmEnabled(Boolean value) {
+    public void setElm327Enabled(boolean value) {
         getSettings().setElm327Enabled(value);
-	}
+    }
 
     private JProgressBar startbar() {
         startStatus = new JWindow();

--- a/src/main/java/com/romraider/logger/ecu/ui/swing/menubar/EcuLoggerMenuBar.java
+++ b/src/main/java/com/romraider/logger/ecu/ui/swing/menubar/EcuLoggerMenuBar.java
@@ -129,7 +129,7 @@ public class EcuLoggerMenuBar extends JMenuBar {
         RadioButtonMenuItem autoRefresh = new RadioButtonMenuItem(rb.getString("COMREFRESH"), VK_E, getKeyStroke(VK_E, CTRL_MASK), new ComPortAutoRefreshAction(logger), logger.getSettings().getRefreshMode());
         autoRefresh.setToolTipText(rb.getString("COMREFRESHTT"));
         settingsMenu.add(autoRefresh);
-        RadioButtonMenuItem elmEnabled = new RadioButtonMenuItem(rb.getString("ELM327ENABLED"), VK_C, getKeyStroke(VK_C, CTRL_MASK), new ElmEnabledAction(logger), logger.getSettings().getElm327Enabled());
+        RadioButtonMenuItem elmEnabled = new RadioButtonMenuItem(rb.getString("ELM327ENABLED"), VK_C, getKeyStroke(VK_C, CTRL_MASK), new ElmEnabledAction(logger), logger.getSettings().isElm327Enabled());
         elmEnabled.setToolTipText(rb.getString("ELM327ENABLEDTT"));
         elmEnabled.setSelected(false);
         logger.getComponentList().put("elmEnabled", elmEnabled);

--- a/src/main/java/com/romraider/logger/ecu/ui/swing/menubar/action/ElmEnabledAction.java
+++ b/src/main/java/com/romraider/logger/ecu/ui/swing/menubar/action/ElmEnabledAction.java
@@ -31,7 +31,7 @@ public final class ElmEnabledAction extends AbstractAction {
 
     public void actionPerformed(ActionEvent actionEvent) {
         try {
-            logger.setElmEnabled((Boolean) getValue(SELECTED_KEY));
+            logger.setElm327Enabled((Boolean) getValue(SELECTED_KEY));
         } catch (Exception e) {
             logger.reportError(e);
         }


### PR DESCRIPTION
## Summary
- use primitive boolean for ELM327 search flag
- rename getter/setter to `isElm327Enabled` and `setElm327Enabled`
- update menu action and connection factory to use new names

## Testing
- `ant unittest` *(fails: Unable to create javax script engine for javascript)*

------
https://chatgpt.com/codex/tasks/task_e_68a749911dcc83249f06e737ae47db36